### PR TITLE
Customizable Layouts

### DIFF
--- a/src/components/CollectionGallery/CollectionGallery.js
+++ b/src/components/CollectionGallery/CollectionGallery.js
@@ -1,92 +1,35 @@
-import { Paper } from '@mui/material';
-import { LeftColumn, RightColumn } from 'components/Layout';
-import React from 'react';
-import { FixedSizeGrid } from 'react-window';
-import AutoSizer from 'react-virtualized-auto-sizer';
-
 import { TraitFilterContextConsumer, TraitFilterContextProvider } from 'contexts/TraitFilterContext';
 
-import { Content } from 'components/Layout';
-import CurrentFilters from 'components/CurrentFilters';
-import GalleryItem from './GalleryItem';
-import TraitFilters from 'components/TraitFilters';
+import DefaultCurrentFiltersLayout from 'components/DefaultCurrentFiltersLayout';
+import DefaultFiltersLayout from 'components/DefaultFiltersLayout';
+import DefaultGalleryLayout from 'components/DefaultGalleryLayout';
+import DefaultTokensLayout from 'components/DefaultTokensLayout';
+import React from 'react';
 
-const CollectionGallery = ({ tokens }) => {
+const withTraitFilterContextConsumer = (Component) => (props) =>
+  <Component
+    TraitFilterContextConsumer={TraitFilterContextConsumer}
+    {...props} />
+
+const CollectionGallery = ({
+  tokens,
+  GalleryLayout = DefaultGalleryLayout,
+  FiltersLayout = DefaultFiltersLayout,
+  TokensLayout = DefaultTokensLayout,
+  CurrentFiltersLayout = DefaultCurrentFiltersLayout,
+}) => {
+  const DecoratedGalleryLayout = withTraitFilterContextConsumer(GalleryLayout);
+  const DecoratedFiltersLayout = withTraitFilterContextConsumer(FiltersLayout);
+  const DecoratedTokensLayout = withTraitFilterContextConsumer(TokensLayout);
+  const DecoratedCurrentFiltersLayout = withTraitFilterContextConsumer(CurrentFiltersLayout);
   return (
-    <Paper
-      elevation={3}
-      sx={{ position: 'fixed', top: 0, bottom: 0, left: 0, right: 0, zIndex: 999, p: 1 }}
-    >
-      <TraitFilterContextProvider tokens={tokens}>
-        <Content sx={{ flexDirection: 'row' }}>
-          <LeftColumn>
-            <LeftColumn.ColumnBox>
-              <TraitFilterContextConsumer>
-                {({ variationNamesByTraitName, tokensByVariationName, selectedFilters, setSelectedFilters }) =>
-                  <TraitFilters
-                    variationNamesByTraitName={variationNamesByTraitName}
-                    getCount={(key) => tokensByVariationName[key].length}
-                    onChange={({ target: { name, checked } }) => {
-                      setSelectedFilters({
-                        ...selectedFilters,
-                        [name]: checked
-                      })
-                    }}
-                    isChecked={(key) => selectedFilters[key]} />
-                }
-              </TraitFilterContextConsumer>
-            </LeftColumn.ColumnBox>
-          </LeftColumn>
-          <RightColumn>
-              <TraitFilterContextConsumer>
-                {({ selectedFilters, removeFilter }) =>
-                  <CurrentFilters filters={selectedFilters} onDelete={removeFilter} />
-                }
-              </TraitFilterContextConsumer>
-              <TraitFilterContextConsumer>
-                {({ filteredTokens }) =>
-                    <AutoSizer>
-                      {({ height, width }) => {
-                        const ROW_GUTTER = 20;
-                        const COLUMN_GUTTER = 20;
-                        const CARD_WIDTH = 250;
-                        const CARD_HEIGHT = 290;
-
-                        const columnCount = Math.floor(width / (CARD_WIDTH + COLUMN_GUTTER));
-                        const rowCount = Math.ceil(filteredTokens.length / columnCount);
-
-                        return (
-                          <FixedSizeGrid
-                            columnCount={columnCount}
-                            columnWidth={width / columnCount}
-                            height={height}
-                            rowCount={rowCount}
-                            rowHeight={CARD_HEIGHT + ROW_GUTTER}
-                            width={width}
-                          >
-                            {({ columnIndex, rowIndex, style }) => {
-                              const token = filteredTokens[rowIndex * columnCount + columnIndex];
-
-                              if (!token) {
-                                return null;
-                              }
-                              
-                              return (
-                                <div style={style}>
-                                  <GalleryItem token={token} />
-                                </div>
-                              )
-                            }}
-                          </FixedSizeGrid>
-                        )
-                      }}
-                    </AutoSizer>
-                }
-              </TraitFilterContextConsumer>
-          </RightColumn>
-        </Content>
-      </TraitFilterContextProvider>
-    </Paper>
+    <TraitFilterContextProvider tokens={tokens}>
+      <DecoratedGalleryLayout
+        FiltersLayout={DecoratedFiltersLayout}
+        TokensLayout={DecoratedTokensLayout}
+        CurrentFiltersLayout={DecoratedCurrentFiltersLayout}
+      />
+    </TraitFilterContextProvider >
   )
 }
 

--- a/src/components/DefaultCurrentFiltersLayout/DefaultCurrentFiltersLayout.js
+++ b/src/components/DefaultCurrentFiltersLayout/DefaultCurrentFiltersLayout.js
@@ -1,0 +1,12 @@
+import React, { Fragment } from 'react';
+
+import CurrentFilters from 'components/CurrentFilters';
+
+const DefaultCurrentFiltersLayout = ({ TraitFilterContextConsumer }) =>
+  <Fragment>
+    <TraitFilterContextConsumer>
+      {({ selectedFilters, removeFilter }) => <CurrentFilters filters={selectedFilters} onDelete={removeFilter} />}
+    </TraitFilterContextConsumer>
+  </Fragment>;
+
+export default DefaultCurrentFiltersLayout;

--- a/src/components/DefaultCurrentFiltersLayout/index.js
+++ b/src/components/DefaultCurrentFiltersLayout/index.js
@@ -1,0 +1,1 @@
+export { default } from './DefaultCurrentFiltersLayout';

--- a/src/components/DefaultFiltersLayout/DefaultFiltersLayout.js
+++ b/src/components/DefaultFiltersLayout/DefaultFiltersLayout.js
@@ -1,0 +1,25 @@
+import { LeftColumn } from 'components/Layout';
+import React from 'react';
+import TraitFilters from 'components/TraitFilters';
+
+const DefaultFiltersLayout = ({ TraitFilterContextConsumer }) =>
+  <LeftColumn>
+    <LeftColumn.ColumnBox>
+      <TraitFilterContextConsumer>
+        {({ variationNamesByTraitName, tokensByVariationName, selectedFilters, setSelectedFilters }) =>
+          <TraitFilters
+            variationNamesByTraitName={variationNamesByTraitName}
+            getCount={(key) => tokensByVariationName[key].length}
+            onChange={({ target: { name, checked } }) => {
+              setSelectedFilters({
+                ...selectedFilters,
+                [name]: checked
+              });
+            }}
+            isChecked={(key) => selectedFilters[key]} />
+        }
+      </TraitFilterContextConsumer>
+    </LeftColumn.ColumnBox>
+  </LeftColumn>;
+
+export default DefaultFiltersLayout;

--- a/src/components/DefaultFiltersLayout/index.js
+++ b/src/components/DefaultFiltersLayout/index.js
@@ -1,0 +1,1 @@
+export { default } from './DefaultFiltersLayout';

--- a/src/components/DefaultGalleryLayout/DefaultGalleryLayout.js
+++ b/src/components/DefaultGalleryLayout/DefaultGalleryLayout.js
@@ -1,0 +1,20 @@
+import { Content } from 'components/Layout';
+import { Paper } from '@mui/material';
+import React from 'react';
+import { RightColumn } from 'components/Layout';
+
+const DefaultGalleryLayout = ({ TraitFilterContextConsumer, FiltersLayout, TokensLayout, CurrentFiltersLayout }) =>
+  <Paper
+    elevation={3}
+    sx={{ position: 'fixed', top: 0, bottom: 0, left: 0, right: 0, zIndex: 999, p: 1 }}
+  >
+    <Content sx={{ flexDirection: 'row' }}>
+      <FiltersLayout />
+      <RightColumn>
+        <CurrentFiltersLayout />
+        <TokensLayout />
+      </RightColumn>
+    </Content>
+  </Paper>;
+
+export default DefaultGalleryLayout;

--- a/src/components/DefaultGalleryLayout/index.js
+++ b/src/components/DefaultGalleryLayout/index.js
@@ -1,0 +1,1 @@
+export { default } from './DefaultGalleryLayout';

--- a/src/components/DefaultTokensLayout/DefaultTokensLayout.js
+++ b/src/components/DefaultTokensLayout/DefaultTokensLayout.js
@@ -1,0 +1,49 @@
+import React, { Fragment } from 'react';
+
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { FixedSizeGrid } from 'react-window';
+import GalleryItem from '../CollectionGallery/GalleryItem';
+
+const DefaultTokensLayout = ({ TraitFilterContextConsumer }) =>
+  <Fragment>
+    <TraitFilterContextConsumer>
+      {({ filteredTokens }) => <AutoSizer>
+        {({ height, width }) => {
+          const ROW_GUTTER = 20;
+          const COLUMN_GUTTER = 20;
+          const CARD_WIDTH = 250;
+          const CARD_HEIGHT = 290;
+
+          const columnCount = Math.floor(width / (CARD_WIDTH + COLUMN_GUTTER));
+          const rowCount = Math.ceil(filteredTokens.length / columnCount);
+
+          return (
+            <FixedSizeGrid
+              columnCount={columnCount}
+              columnWidth={width / columnCount}
+              height={height}
+              rowCount={rowCount}
+              rowHeight={CARD_HEIGHT + ROW_GUTTER}
+              width={width}
+            >
+              {({ columnIndex, rowIndex, style }) => {
+                const token = filteredTokens[rowIndex * columnCount + columnIndex];
+
+                if (!token) {
+                  return null;
+                }
+
+                return (
+                  <div style={style}>
+                    <GalleryItem token={token} />
+                  </div>
+                );
+              }}
+            </FixedSizeGrid>
+          );
+        }}
+      </AutoSizer>}
+    </TraitFilterContextConsumer>
+  </Fragment>;
+
+export default DefaultTokensLayout;

--- a/src/components/DefaultTokensLayout/index.js
+++ b/src/components/DefaultTokensLayout/index.js
@@ -1,0 +1,1 @@
+export { default } from './DefaultTokensLayout';


### PR DESCRIPTION
In effort of decoupling MUI, I extracted out the design to its own files and introduced an API design that would enable other developers to customize the default design more easily. In each new Layout component, there will be a Consumer injected as a prop. The consumer has all the token related data and will be useful for more unique customizations.

In a subsequent PR, I will be removing MUI in favor of ~~Tailwind CSS~~ basic CSS simplifying the design into a bare skeleton to minimize the build size. I'll also extract the existing MUI design into a separate repo, so people can quickly drop the theme in and use it if they wished to.